### PR TITLE
Multiple Improvements to INI Packaged Build file writing

### DIFF
--- a/BugSplat.uplugin
+++ b/BugSplat.uplugin
@@ -24,7 +24,7 @@
 	"PostBuildSteps":
 	{
 		"Win64": [
-			"call \"$(ProjectDir)\\Plugins\\BugSplat\\Source\\Shell\\BugSplat.bat\" $(TargetPlatform)"
+			"call \"$(ProjectDir)\\Plugins\\BugSplat\\Source\\Scripts\\BugSplat.bat\" $(TargetPlatform)"
 		]
 	}
 }

--- a/Source/BugSplat/Public/BugSplatSettings.h
+++ b/Source/BugSplat/Public/BugSplatSettings.h
@@ -7,11 +7,17 @@ static const FString BUGSPLAT_ENDPOINT_URL_FORMAT = FString("https://{0}.bugspla
 static const FString BUGSPLAT_SENDPDBS_DIR = *FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), FString("/Plugins/BugSplat/Source/Scripts/bin/SendPdbs.exe"));
 static const FString BUGSPLAT_BASH_DIR = *FPaths::Combine(FPaths::ProjectDir(), FString("/Plugins/BugSplat/Source/Scripts/BugSplat.bat"));
 
-static const FString LOCAL_CONFIG_PATH = *FPaths::Combine(FPaths::ProjectDir(), FString("/Config/DefaultEngine.ini"));
 static const FString GLOBAL_CRASH_REPORT_CLIENT_CONFIG_PATH = *FPaths::Combine(FPaths::EngineDir(), FString("/Programs/CrashReportClient/Config/DefaultEngine.ini"));
-static const FString PACKAGED_BUILD_CONFIG_PATH = FString("Engine\\Restricted\\NoRedist\\Programs\\CrashReportClient\\Config\\DefaultEngine.ini");
 static const FString BUGSPLAT_UPROJECT_PATH = *FPaths::Combine(FPaths::ProjectDir(), FString("/Plugins/BugSplat/BugSplat.uplugin"));
 
+static const FString PACKAGED_BUILD_CONFIG_PATH_5 = FString("Engine\\Restricted\\NoRedist\\Programs\\CrashReportClient\\Config");
+static const FString PACKAGED_BUILD_CONFIG_PATH_4_26_TO_5 = FString("Engine\\Restricted\\NoRedist\\Programs\\CrashReportClient\\Config");
+static const FString PACKAGED_BUILD_CONFIG_PATH_4_25_AND_OLDER = FString("Engine\\Programs\\CrashReportClient\\Config\\NoRedist");
+
+static const FString INI_FILE_NAME = FString("DefaultEngine.ini");
+
+static const FString PACKAGED_BUILD_ROOT_5 = FString("Windows");
+static const FString PACKAGED_BUILD_ROOT_OLDER_THAN_5 = FString("WindowsNoEditor");
 static const FString DATABASE_TAG = FString("Database");
 static const FString APP_NAME_TAG = FString("AppName");
 static const FString VERSION_TAG = FString("AppVersion"); // "Version" is reserved for plugin version.


### PR DESCRIPTION
### Description

I've updated the INI Local packaged system in the following ways.
- [x] We will change the path we attempt to write to depending on the version of UE.
- [x] If the folder path that we expect does not exist, we will create all necessary directories and files.

Additionally, I noticed that the bash file moved directories, and I updated the PostBuildSteps in the uproject file to reflect that. 

Fixes #6 Fixes #14

### Checklist

- [x] Tested manually (Tested against 4.26, will test against 5 and 4.25 when I have the time to download corresponding engines)
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
