### PR TITLE
fix: plugins dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,10 +70,8 @@ Plugins/*/Intermediate/*
 # Cache files for the editor to use
 DerivedDataCache/*
 
-# Ignore SendPdbs
-!Source/Scripts/bin/SendPdbs.exe
-!Source/Scripts/bin/AWSSDK.Core.dll
-!Source/Scripts/bin/AWSSDK.S3.dll
+# Ignore auto-generated upload script
+Source/Scripts/BugSplat.bat
 
 # Mac OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ Source/Scripts/BugSplat.bat
 
 # Mac OS
 .DS_Store
+
+# Symbol Upload temp files
+Source/Scripts/tmp

--- a/Source/BugSplat/Private/BugSplatSettings.cpp
+++ b/Source/BugSplat/Private/BugSplatSettings.cpp
@@ -8,9 +8,9 @@
 #include "BugSplatEditorSettings.h"
 #include "BugSplatRuntime.h"
 
-FBugSplatSettings::FBugSplatSettings(FString UProjectFilePath)
+FBugSplatSettings::FBugSplatSettings()
 {
-	FBugSplatSettings::UProjectFilePath = UProjectFilePath;
+
 }
 
 FString FBugSplatSettings::CreateBugSplatEndpointUrl()
@@ -54,33 +54,41 @@ void FBugSplatSettings::UpdateCrashReportClientIni(FString DefaultEngineIniFileP
 
 void FBugSplatSettings::WriteSymbolUploadScript()
 {
+	FString SetCurrentPlatfrom = FString("set targetPlatform=%1");
+	FString TargetPlatformNullGuard = FString("if \"%targetPlatform%\"==\"\" (\n\techo \"BugSplat [ERROR]: symbol upload invocation missing target platform...\"\n\texit /b\n)");
+	FString EditorPlatformGuard = FString("if \"%targetPlatform%\"==\"Editor\" (\n\techo \"BugSplat [INFO]: Editor build detected, skipping symbol uploads...\"\n\texit /b\n)");
+	UBugSplatEditorSettings* RuntimeSettings = FBugSplatRuntimeModule::Get().GetSettings();
+
 	FString PostBuildStepsConsoleCommandFormat =
 		FString(
-			"\"{0}\" "	 // Uploader Path
-			"-i {1} "	 // Client ID
-			"-s {2} "	 // Client Secret
-			"-b {3} "	 // Database
-			"-a {4} "	 // Application
-			"-v {5} "	 // Version
-			"-d \"{6}\" " // Project Directory
-			"-f \"{7}\" " // File Pattern
+			"{0}\n"		  // Set Platform
+			"{1}\n"		  // Target Platform Null Guard
+			"{2}\n"		  // Editor Platform Guard
+			"\"{3}\" "	  // Uploader Path
+			"-i {4} "	  // Client ID
+			"-s {5} "	  // Client Secret
+			"-b {6} "	  // Database
+			"-a {7} "	  // Application
+			"-v {8} "	  // Version
+			"-d \"{9}\" " // Project Directory
+			"-f \"{10}\" " // File Pattern
 		);
 
 	FStringFormatOrderedArguments args;
-
-	UBugSplatEditorSettings* runtimeSettings = FBugSplatRuntimeModule::Get().GetSettings();
-
+	args.Add(SetCurrentPlatfrom);
+	args.Add(TargetPlatformNullGuard);
+	args.Add(EditorPlatformGuard);
 	args.Add(BUGSPLAT_SYMBOL_UPLOADER_PATH);
-	args.Add(runtimeSettings->BugSplatClientId);
-	args.Add(runtimeSettings->BugSplatClientSecret);
-	args.Add(runtimeSettings->BugSplatDatabase);
-	args.Add(runtimeSettings->BugSplatApp);
-	args.Add(runtimeSettings->BugSplatVersion);
+	args.Add(RuntimeSettings->BugSplatClientId);
+	args.Add(RuntimeSettings->BugSplatClientSecret);
+	args.Add(RuntimeSettings->BugSplatDatabase);
+	args.Add(RuntimeSettings->BugSplatApp);
+	args.Add(RuntimeSettings->BugSplatVersion);
 	args.Add(FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), "Binaries"));
 	args.Add("**/*.{pdb,dll,exe}");
-
-	FString FormattedString = *FString::Format(*PostBuildStepsConsoleCommandFormat, args);
-	FFileHelper::SaveStringToFile(FormattedString, *BUGSPLAT_BASH_DIR);
+	
+	FString UploadSymbolsScript = FString::Format(*PostBuildStepsConsoleCommandFormat, args);
+	FFileHelper::SaveStringToFile(UploadSymbolsScript, *BUGSPLAT_BASH_DIR);
 	FMessageDialog::Debugf(FText::FromString("Symbol uploads added successfully!"));
 }
 

--- a/Source/BugSplat/Public/BugSplatSettings.h
+++ b/Source/BugSplat/Public/BugSplatSettings.h
@@ -4,13 +4,15 @@
 
 #include "CoreMinimal.h"
 #include <EngineSharedPCH.h>
+#include "Interfaces/IPluginManager.h"
+
+static const FString PLUGIN_BASE_DIR = FPaths::ConvertRelativePathToFull(IPluginManager::Get().FindPlugin(TEXT("BugSplat"))->GetBaseDir());
 
 static const FString BUGSPLAT_ENDPOINT_URL_FORMAT = FString("https://{0}.bugsplat.com/post/ue4/{1}/{2}");
-static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), FString("Plugins/BugSplat/Source/ThirdParty/SymUploader/symbol-upload-win.exe"));
+static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(PLUGIN_BASE_DIR, FString("/Source/ThirdParty/SymUploader/symbol-upload-win.exe"));
 static const FString BUGSPLAT_BASH_DIR = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/Source/Scripts/BugSplat.bat"));
 
 static const FString GLOBAL_CRASH_REPORT_CLIENT_CONFIG_PATH = *FPaths::Combine(FPaths::EngineDir(), FString("Programs/CrashReportClient/Config/DefaultEngine.ini"));
-static const FString BUGSPLAT_UPROJECT_PATH = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/BugSplat.uplugin"));
 
 static const FString PACKAGED_BUILD_CONFIG_PATH_5 = FString("Engine\\Restricted\\NoRedist\\Programs\\CrashReportClient\\Config");
 static const FString PACKAGED_BUILD_CONFIG_PATH_4_26_TO_5 = FString("Engine\\Restricted\\NoRedist\\Programs\\CrashReportClient\\Config");
@@ -21,7 +23,7 @@ static const FString INI_FILE_NAME = FString("DefaultEngine.ini");
 class FBugSplatSettings
 {
 public:
-	FBugSplatSettings(FString uProjectFilePath);
+	FBugSplatSettings();
 
 	FString CreateBugSplatEndpointUrl();
 
@@ -34,6 +36,4 @@ private:
 	FString GetPackagedBuildDefaultEngineIniRelativePath();
 	void CreateEmptyTextFile(FString FullPath);
 	void UpdateCrashReportClientIni(FString iniFilePath);
-
-	FString UProjectFilePath;
 };

--- a/Source/Scripts/BugSplat.bat
+++ b/Source/Scripts/BugSplat.bat
@@ -1,1 +1,0 @@
-echo BugSplat has not been configured, so no PDBS will be uploaded!

--- a/Source/Scripts/upload-symbols-win64.bat
+++ b/Source/Scripts/upload-symbols-win64.bat
@@ -1,0 +1,12 @@
+echo off
+
+set targetPlatform=%1
+set pluginDir=%2
+set uploadScriptPath=%pluginDir%\BugSplat.bat
+
+IF NOT EXIST %uploadScriptPath% (
+	echo "BugSplat [WARN]: symbol uploads not configured via plugin - skipping..."
+	exit /b
+)
+
+call %uploadScriptPath% %targetPlatform%


### PR DESCRIPTION
### Description

Path to plugins dir was hard coded to the path of the project plugin - store plugins are installed in the Engine plugins dir. Also updates BugSplat.bat to not upload symbols for Editor builds.

Fixes #51 Fixes #50

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
