### PR TITLE
chore: fix symbol uploads for Win64

### DIFF
--- a/BugSplat.uplugin
+++ b/BugSplat.uplugin
@@ -29,7 +29,7 @@
 	],
 	"PostBuildSteps": {
 		"Win64": [
-			"call \"$(ProjectDir)\\Plugins\\BugSplat\\Source\\Scripts\\BugSplat.bat\" $(TargetPlatform)"
+			"call \"$(ProjectDir)\\Plugins\\BugSplat\\Source\\Scripts\\upload-symbols-win64.bat\" $(TargetPlatform) $(ProjectDir)"
 		],
 		"Mac": [
 			"sh $(PluginDir)/Source/Scripts/setup-upload-symbols-ios.sh $(TargetPlatform) $(TargetName) $(ProjectDir) $(PluginDir)"

--- a/Source/Scripts/upload-symbols-win64.bat
+++ b/Source/Scripts/upload-symbols-win64.bat
@@ -1,10 +1,12 @@
 echo off
 
 set targetPlatform=%1
-set pluginDir=%2
-set uploadScriptPath=%pluginDir%\BugSplat.bat
+set projectDir=%2
+set uploadScriptPath=%projectDir%\Plugins\BugSplat\Source\Scripts\BugSplat.bat
 
-IF NOT EXIST %uploadScriptPath% (
+echo "BugSplat [INFO]: invoking upload script at %uploadScriptPath%"
+
+if not exist "%uploadScriptPath%" (
 	echo "BugSplat [WARN]: symbol uploads not configured via plugin - skipping..."
 	exit /b
 )


### PR DESCRIPTION
### Description

When I tested it must've still be using the old stuff. I've verified this does in fact uploads symbols!

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
