### PR TITLE
chore: post build script updates

### DIFF
--- a/BugSplat.uplugin
+++ b/BugSplat.uplugin
@@ -29,7 +29,7 @@
 	],
 	"PostBuildSteps": {
 		"Win64": [
-			"call \"$(ProjectDir)\\Plugins\\BugSplat\\Source\\Scripts\\upload-symbols-win64.bat\" $(TargetPlatform) $(ProjectDir)"
+			"call \"$(PluginDir)\\Source\\Scripts\\upload-symbols-win64.bat\" $(TargetPlatform) $(ProjectDir)"
 		],
 		"Mac": [
 			"sh $(PluginDir)/Source/Scripts/setup-upload-symbols-ios.sh $(TargetPlatform) $(TargetName) $(ProjectDir) $(PluginDir)"

--- a/Source/BugSplat/Private/BugSplatSettings.cpp
+++ b/Source/BugSplat/Private/BugSplatSettings.cpp
@@ -54,7 +54,7 @@ void FBugSplatSettings::UpdateCrashReportClientIni(FString DefaultEngineIniFileP
 
 void FBugSplatSettings::WriteSymbolUploadScript()
 {
-	FString SetCurrentPlatfrom = FString("set targetPlatform=%1");
+	FString SetCurrentPlatfrom = FString("@echo off\nset targetPlatform=%1");
 	FString TargetPlatformNullGuard = FString("if \"%targetPlatform%\"==\"\" (\n\techo \"BugSplat [ERROR]: symbol upload invocation missing target platform...\"\n\texit /b\n)");
 	FString EditorPlatformGuard = FString("if \"%targetPlatform%\"==\"Editor\" (\n\techo \"BugSplat [INFO]: Editor build detected, skipping symbol uploads...\"\n\texit /b\n)");
 	UBugSplatEditorSettings* RuntimeSettings = FBugSplatRuntimeModule::Get().GetSettings();

--- a/Source/Scripts/upload-symbols-win64.bat
+++ b/Source/Scripts/upload-symbols-win64.bat
@@ -1,4 +1,4 @@
-echo off
+@echo off
 
 set targetPlatform=%1
 set projectDir=%2


### PR DESCRIPTION
### Description

Up until now I haven't had a good way to test plugin changes. Seems like just building as a project plugin and copying to the Engine plugin dir works good enough. Now that I can test I can smoke out silly bugs like this.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
