### PR TITLE
feat: auto-update DataRouterUrl

### DIFF
--- a/BugSplat.uplugin
+++ b/BugSplat.uplugin
@@ -35,7 +35,7 @@
     ],
     "PostBuildSteps": {
         "Win64": [
-            "call \"$(PluginDir)\\Source\\Scripts\\upload-symbols-win64.bat\" $(TargetPlatform) $(ProjectDir)"
+            "call \"$(PluginDir)\\Source\\Scripts\\upload-symbols-win64.bat\" $(TargetPlatform) $(ProjectDir) $(TargetName)"
         ],
         "Mac": [
             "sh $(PluginDir)/Source/Scripts/setup-upload-symbols-ios.sh $(TargetPlatform) $(TargetName) $(ProjectDir) $(PluginDir)"

--- a/Source/BugSplat/BugSplat.Build.cs
+++ b/Source/BugSplat/BugSplat.Build.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 using UnrealBuildTool;
 

--- a/Source/BugSplat/Private/BugSplat.cpp
+++ b/Source/BugSplat/Private/BugSplat.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplat.h"
 #include "BugSplatSettings.h"

--- a/Source/BugSplat/Private/BugSplat.cpp
+++ b/Source/BugSplat/Private/BugSplat.cpp
@@ -1,7 +1,7 @@
 // Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplat.h"
-#include "BugSplatSettings.h"
+#include "BugSplatCrashReportClient.h"
 #include "BugSplatSettingsCustomization.h"
 #include "LevelEditor.h"
 #include "Widgets/Docking/SDockTab.h"

--- a/Source/BugSplat/Private/BugSplat.cpp
+++ b/Source/BugSplat/Private/BugSplat.cpp
@@ -2,7 +2,7 @@
 
 #include "BugSplat.h"
 #include "BugSplatCrashReportClient.h"
-#include "BugSplatSettingsCustomization.h"
+#include "BugSplatEditorSettingsCustomization.h"
 #include "LevelEditor.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Layout/SBox.h"
@@ -33,7 +33,7 @@ void FBugSplatModule::StartupModule()
 	auto& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
 	PropertyModule.RegisterCustomClassLayout(
 		"BugSplatEditorSettings",
-		FOnGetDetailCustomizationInstance::CreateStatic(&FBugSplatSettingsCustomization::MakeInstance));
+		FOnGetDetailCustomizationInstance::CreateStatic(&FBugSplatEditorSettingsCustomization::MakeInstance));
 
 	PropertyModule.NotifyCustomizationModuleChanged();
 }

--- a/Source/BugSplat/Private/BugSplat.cpp
+++ b/Source/BugSplat/Private/BugSplat.cpp
@@ -12,6 +12,8 @@
 #include <Runtime/Projects/Public/PluginDescriptor.h>
 #include <EngineSharedPCH.h>
 #include <Editor/MainFrame/Public/Interfaces/IMainFrameModule.h>
+#include <BugSplatEditorSettings.h>
+#include "BugSplatRuntime.h"
 
 static const FName BugSplatTabName("BugSplat");
 
@@ -40,7 +42,7 @@ void FBugSplatModule::StartupModule()
 
 void FBugSplatModule::ShutdownModule()
 {
-	delete BugSplatSettings;
+	delete BugSplatCrashReportClient;
 	delete BugSplatSymbols;
 
 	if (FModuleManager::Get().IsModuleLoaded("PropertyEditor"))
@@ -55,21 +57,15 @@ FBugSplatModule& FBugSplatModule::Get()
 	return FModuleManager::LoadModuleChecked<FBugSplatModule>("BugSplat");
 }
 
-FReply FBugSplatModule::OnUpdateGlobalIni()
+void FBugSplatModule::OnUpdateBugSplatSettings()
 {
-	BugSplatSettings->UpdateGlobalIni();
-	return FReply::Handled();
+	BugSplatCrashReportClient->UpdateEngineSettings();
+	BugSplatSymbols->UpdateSymbolUploadsSettings();
 }
 
 FReply FBugSplatModule::OnUpdateLocalIni()
 {
-	BugSplatSettings->UpdateLocalIni();
-	return FReply::Handled();
-}
-
-FReply FBugSplatModule::OnUpdateWindowsSymbolUploadScript()
-{
-	BugSplatSymbols->WriteSymbolUploadScript();
+	BugSplatCrashReportClient->UpdatePackagedBuildSettings();
 	return FReply::Handled();
 }
 

--- a/Source/BugSplat/Private/BugSplat.cpp
+++ b/Source/BugSplat/Private/BugSplat.cpp
@@ -41,6 +41,7 @@ void FBugSplatModule::StartupModule()
 void FBugSplatModule::ShutdownModule()
 {
 	delete BugSplatSettings;
+	delete BugSplatSymbols;
 
 	if (FModuleManager::Get().IsModuleLoaded("PropertyEditor"))
 	{
@@ -68,7 +69,7 @@ FReply FBugSplatModule::OnUpdateLocalIni()
 
 FReply FBugSplatModule::OnUpdateWindowsSymbolUploadScript()
 {
-	BugSplatSettings->WriteSymbolUploadScript();
+	BugSplatSymbols->WriteSymbolUploadScript();
 	return FReply::Handled();
 }
 

--- a/Source/BugSplat/Private/BugSplatCrashReportClient.cpp
+++ b/Source/BugSplat/Private/BugSplatCrashReportClient.cpp
@@ -1,6 +1,6 @@
 // Copyright 2023 BugSplat. All Rights Reserved.
 
-#include "BugSplatSettings.h"
+#include "BugSplatCrashReportClient.h"
 #include <Developer/DesktopPlatform/Public/DesktopPlatformModule.h>
 #include <Modules/BuildVersion.h>
 #include <Runtime/Core/Public/Misc/EngineVersionComparison.h>
@@ -8,12 +8,12 @@
 #include "BugSplatEditorSettings.h"
 #include "BugSplatRuntime.h"
 
-FBugSplatSettings::FBugSplatSettings()
+FBugSplatCrashReportClient::FBugSplatCrashReportClient()
 {
 
 }
 
-FString FBugSplatSettings::CreateBugSplatEndpointUrl()
+FString FBugSplatCrashReportClient::CreateBugSplatEndpointUrl()
 {
 	FStringFormatOrderedArguments args;
 
@@ -28,7 +28,7 @@ FString FBugSplatSettings::CreateBugSplatEndpointUrl()
 	return *FString::Format(*BUGSPLAT_ENDPOINT_URL_FORMAT, args);
 }
 
-void FBugSplatSettings::UpdateCrashReportClientIni(FString DefaultEngineIniFilePath)
+void FBugSplatCrashReportClient::UpdateCrashReportClientIni(FString DefaultEngineIniFilePath)
 {
 	if (!FPaths::FileExists(DefaultEngineIniFilePath))
 	{
@@ -54,12 +54,12 @@ void FBugSplatSettings::UpdateCrashReportClientIni(FString DefaultEngineIniFileP
 	FMessageDialog::Debugf(FText::FromString("Configuration File Successfully Updated!"));
 }
 
-void FBugSplatSettings::UpdateGlobalIni()
+void FBugSplatCrashReportClient::UpdateGlobalIni()
 {
 	UpdateCrashReportClientIni(*GLOBAL_CRASH_REPORT_CLIENT_CONFIG_PATH);
 }
 
-void FBugSplatSettings::UpdateLocalIni()
+void FBugSplatCrashReportClient::UpdateLocalIni()
 {
 	FString PackagedBuildFolderPath;
 
@@ -123,18 +123,18 @@ void FBugSplatSettings::UpdateLocalIni()
 	}
 }
 
-void FBugSplatSettings::CreateEmptyTextFile(FString FullPath)
+void FBugSplatCrashReportClient::CreateEmptyTextFile(FString FullPath)
 {
 	FString Empty = FString("");
 	FFileHelper::SaveStringToFile(Empty, *FullPath);
 }
 
-FString FBugSplatSettings::GetPackagedBuildPlatformTarget(FString Platform)
+FString FBugSplatCrashReportClient::GetPackagedBuildPlatformTarget(FString Platform)
 {
 	return ENGINE_MAJOR_VERSION >= 5 ? Platform : Platform + TEXT("NoEditor");
 }
 
-FString FBugSplatSettings::GetPackagedBuildDefaultEngineIniRelativePath()
+FString FBugSplatCrashReportClient::GetPackagedBuildDefaultEngineIniRelativePath()
 {
 	if (ENGINE_MAJOR_VERSION == 5)
 	{

--- a/Source/BugSplat/Private/BugSplatEditorSettingsCustomization.cpp
+++ b/Source/BugSplat/Private/BugSplatEditorSettingsCustomization.cpp
@@ -1,6 +1,6 @@
 // Copyright 2023 BugSplat. All Rights Reserved.
 
-#include "BugSplatSettingsCustomization.h"
+#include "BugSplatEditorSettingsCustomization.h"
 #include "BugSplat.h"
 
 #include "DetailCategoryBuilder.h"
@@ -19,12 +19,12 @@ static void OnDocumentationLinkClicked(const FSlateHyperlinkRun::FMetadata& Meta
 	}
 }
 
-TSharedRef<IDetailCustomization> FBugSplatSettingsCustomization::MakeInstance()
+TSharedRef<IDetailCustomization> FBugSplatEditorSettingsCustomization::MakeInstance()
 {
-	return MakeShareable(new FBugSplatSettingsCustomization);
+	return MakeShareable(new FBugSplatEditorSettingsCustomization);
 }
 
-void FBugSplatSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+void FBugSplatEditorSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
 {
 	IDetailCategoryBuilder& CommonCategory = DetailBuilder.EditCategory(TEXT("Crash Reporter Configuration"));
 	IDetailCategoryBuilder& DesktopCategory = DetailBuilder.EditCategory(TEXT("Desktop"));

--- a/Source/BugSplat/Private/BugSplatSettings.cpp
+++ b/Source/BugSplat/Private/BugSplatSettings.cpp
@@ -19,9 +19,11 @@ FString FBugSplatSettings::CreateBugSplatEndpointUrl()
 
 	UBugSplatEditorSettings* runtimeSettings = FBugSplatRuntimeModule::Get().GetSettings();
 
+	FString Space = " ";
+	FString EncodedSpace = "%20";
 	args.Add(runtimeSettings->BugSplatDatabase);
-	args.Add(runtimeSettings->BugSplatApp);
-	args.Add(runtimeSettings->BugSplatVersion);
+	args.Add(runtimeSettings->BugSplatApp.Replace(*Space, *EncodedSpace));
+	args.Add(runtimeSettings->BugSplatVersion.Replace(*Space, *EncodedSpace));
 
 	return *FString::Format(*BUGSPLAT_ENDPOINT_URL_FORMAT, args);
 }
@@ -68,8 +70,8 @@ void FBugSplatSettings::WriteSymbolUploadScript()
 			"-i {4} "	  // Client ID
 			"-s {5} "	  // Client Secret
 			"-b {6} "	  // Database
-			"-a {7} "	  // Application
-			"-v {8} "	  // Version
+			"-a \"{7}\" " // Application
+			"-v \"{8}\" " // Version
 			"-d \"{9}\" " // Project Directory
 			"-f \"{10}\" " // File Pattern
 		);

--- a/Source/BugSplat/Private/BugSplatSettings.cpp
+++ b/Source/BugSplat/Private/BugSplatSettings.cpp
@@ -54,46 +54,6 @@ void FBugSplatSettings::UpdateCrashReportClientIni(FString DefaultEngineIniFileP
 	FMessageDialog::Debugf(FText::FromString("Configuration File Successfully Updated!"));
 }
 
-void FBugSplatSettings::WriteSymbolUploadScript()
-{
-	FString SetCurrentPlatfrom = FString("@echo off\nset targetPlatform=%1");
-	FString TargetPlatformNullGuard = FString("if \"%targetPlatform%\"==\"\" (\n\techo \"BugSplat [ERROR]: symbol upload invocation missing target platform...\"\n\texit /b\n)");
-	FString EditorPlatformGuard = FString("if \"%targetPlatform%\"==\"Editor\" (\n\techo \"BugSplat [INFO]: Editor build detected, skipping symbol uploads...\"\n\texit /b\n)");
-	UBugSplatEditorSettings* RuntimeSettings = FBugSplatRuntimeModule::Get().GetSettings();
-
-	FString PostBuildStepsConsoleCommandFormat =
-		FString(
-			"{0}\n"		   // Set Platform
-			"{1}\n"		   // Target Platform Null Guard
-			"{2}\n"		   // Editor Platform Guard
-			"\"{3}\" "	   // Uploader Path
-			"-i {4} "	   // Client ID
-			"-s {5} "	   // Client Secret
-			"-b {6} "	   // Database
-			"-a \"{7}\" "  // Application
-			"-v \"{8}\" "  // Version
-			"-d \"{9}/%targetPlatform%\" " // Output Directory
-			"-f \"{10}\" " // File Pattern
-		);
-
-	FStringFormatOrderedArguments args;
-	args.Add(SetCurrentPlatfrom);
-	args.Add(TargetPlatformNullGuard);
-	args.Add(EditorPlatformGuard);
-	args.Add(BUGSPLAT_SYMBOL_UPLOADER_PATH);
-	args.Add(RuntimeSettings->BugSplatClientId);
-	args.Add(RuntimeSettings->BugSplatClientSecret);
-	args.Add(RuntimeSettings->BugSplatDatabase);
-	args.Add(RuntimeSettings->BugSplatApp);
-	args.Add(RuntimeSettings->BugSplatVersion);
-	args.Add(FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), "Binaries"));
-	args.Add("**/*.{pdb,dll,exe}");
-	
-	FString UploadSymbolsScript = FString::Format(*PostBuildStepsConsoleCommandFormat, args);
-	FFileHelper::SaveStringToFile(UploadSymbolsScript, *BUGSPLAT_BASH_DIR);
-	FMessageDialog::Debugf(FText::FromString("Symbol uploads added successfully!"));
-}
-
 void FBugSplatSettings::UpdateGlobalIni()
 {
 	UpdateCrashReportClientIni(*GLOBAL_CRASH_REPORT_CLIENT_CONFIG_PATH);

--- a/Source/BugSplat/Private/BugSplatSettings.cpp
+++ b/Source/BugSplat/Private/BugSplatSettings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplatSettings.h"
 #include <Developer/DesktopPlatform/Public/DesktopPlatformModule.h>
@@ -63,17 +63,17 @@ void FBugSplatSettings::WriteSymbolUploadScript()
 
 	FString PostBuildStepsConsoleCommandFormat =
 		FString(
-			"{0}\n"		  // Set Platform
-			"{1}\n"		  // Target Platform Null Guard
-			"{2}\n"		  // Editor Platform Guard
-			"\"{3}\" "	  // Uploader Path
-			"-i {4} "	  // Client ID
-			"-s {5} "	  // Client Secret
-			"-b {6} "	  // Database
-			"-a \"{7}\" " // Application
-			"-v \"{8}\" " // Version
+			"{0}\n"		   // Set Platform
+			"{1}\n"		   // Target Platform Null Guard
+			"{2}\n"		   // Editor Platform Guard
+			"\"{3}\" "	   // Uploader Path
+			"-i {4} "	   // Client ID
+			"-s {5} "	   // Client Secret
+			"-b {6} "	   // Database
+			"-a \"{7}\" "  // Application
+			"-v \"{8}\" "  // Version
 			"-d \"{9}/%targetPlatform%\" " // Output Directory
-			"-f \"{10}\" "	// File Pattern
+			"-f \"{10}\" " // File Pattern
 		);
 
 	FStringFormatOrderedArguments args;

--- a/Source/BugSplat/Private/BugSplatSettings.cpp
+++ b/Source/BugSplat/Private/BugSplatSettings.cpp
@@ -72,8 +72,8 @@ void FBugSplatSettings::WriteSymbolUploadScript()
 			"-b {6} "	  // Database
 			"-a \"{7}\" " // Application
 			"-v \"{8}\" " // Version
-			"-d \"{9}\" " // Project Directory
-			"-f \"{10}\" " // File Pattern
+			"-d \"{9}/%targetPlatform%\" " // Output Directory
+			"-f \"{10}\" "	// File Pattern
 		);
 
 	FStringFormatOrderedArguments args;

--- a/Source/BugSplat/Private/BugSplatSettingsCustomization.cpp
+++ b/Source/BugSplat/Private/BugSplatSettingsCustomization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplatSettingsCustomization.h"
 #include "BugSplat.h"

--- a/Source/BugSplat/Private/BugSplatSymbols.cpp
+++ b/Source/BugSplat/Private/BugSplatSymbols.cpp
@@ -1,0 +1,54 @@
+// Copyright 2023 BugSplat. All Rights Reserved.
+
+#include "BugSplatSymbols.h"
+#include <Developer/DesktopPlatform/Public/DesktopPlatformModule.h>
+#include <Modules/BuildVersion.h>
+#include <Runtime/Core/Public/Misc/EngineVersionComparison.h>
+
+#include "BugSplatEditorSettings.h"
+#include "BugSplatRuntime.h"
+
+FBugSplatSymbols::FBugSplatSymbols()
+{
+
+}
+
+void FBugSplatSymbols::WriteSymbolUploadScript()
+{
+	FString SetCurrentPlatfrom = FString("@echo off\nset targetPlatform=%1");
+	FString TargetPlatformNullGuard = FString("if \"%targetPlatform%\"==\"\" (\n\techo \"BugSplat [ERROR]: symbol upload invocation missing target platform...\"\n\texit /b\n)");
+	FString EditorPlatformGuard = FString("if \"%targetPlatform%\"==\"Editor\" (\n\techo \"BugSplat [INFO]: Editor build detected, skipping symbol uploads...\"\n\texit /b\n)");
+	UBugSplatEditorSettings* RuntimeSettings = FBugSplatRuntimeModule::Get().GetSettings();
+
+	FString PostBuildStepsConsoleCommandFormat =
+		FString(
+			"{0}\n"		   // Set Platform
+			"{1}\n"		   // Target Platform Null Guard
+			"{2}\n"		   // Editor Platform Guard
+			"\"{3}\" "	   // Uploader Path
+			"-i {4} "	   // Client ID
+			"-s {5} "	   // Client Secret
+			"-b {6} "	   // Database
+			"-a \"{7}\" "  // Application
+			"-v \"{8}\" "  // Version
+			"-d \"{9}/%targetPlatform%\" " // Output Directory
+			"-f \"{10}\" " // File Pattern
+		);
+
+	FStringFormatOrderedArguments args;
+	args.Add(SetCurrentPlatfrom);
+	args.Add(TargetPlatformNullGuard);
+	args.Add(EditorPlatformGuard);
+	args.Add(BUGSPLAT_SYMBOL_UPLOADER_PATH);
+	args.Add(RuntimeSettings->BugSplatClientId);
+	args.Add(RuntimeSettings->BugSplatClientSecret);
+	args.Add(RuntimeSettings->BugSplatDatabase);
+	args.Add(RuntimeSettings->BugSplatApp);
+	args.Add(RuntimeSettings->BugSplatVersion);
+	args.Add(FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), "Binaries"));
+	args.Add("**/*.{pdb,dll,exe}");
+	
+	FString UploadSymbolsScript = FString::Format(*PostBuildStepsConsoleCommandFormat, args);
+	FFileHelper::SaveStringToFile(UploadSymbolsScript, *BUGSPLAT_BASH_DIR);
+	FMessageDialog::Debugf(FText::FromString("Symbol uploads added successfully!"));
+}

--- a/Source/BugSplat/Public/BugSplat.h
+++ b/Source/BugSplat/Public/BugSplat.h
@@ -5,7 +5,7 @@
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 #include <Runtime/SlateCore/Public/Widgets/SUserWidget.h>
-#include "BugSplatSettings.h"
+#include "BugSplatCrashReportClient.h"
 #include "BugSplatSymbols.h"
 
 class FBugSplatModule : public IModuleInterface
@@ -27,6 +27,6 @@ public:
 
 private:
 	TSharedPtr<class FUICommandList> PluginCommands;
-	FBugSplatSettings* BugSplatSettings;
+	FBugSplatCrashReportClient* BugSplatSettings;
 	FBugSplatSymbols* BugSplatSymbols;
 };

--- a/Source/BugSplat/Public/BugSplat.h
+++ b/Source/BugSplat/Public/BugSplat.h
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #pragma once
 

--- a/Source/BugSplat/Public/BugSplat.h
+++ b/Source/BugSplat/Public/BugSplat.h
@@ -21,12 +21,11 @@ public:
 	/** This function will be bound to Command (by default it will bring up plugin window) */
 	void PluginButtonClicked();
 
-	FReply OnUpdateGlobalIni();
+	void OnUpdateBugSplatSettings();
 	FReply OnUpdateLocalIni();
-	FReply OnUpdateWindowsSymbolUploadScript();
 
 private:
 	TSharedPtr<class FUICommandList> PluginCommands;
-	FBugSplatCrashReportClient* BugSplatSettings;
+	FBugSplatCrashReportClient* BugSplatCrashReportClient;
 	FBugSplatSymbols* BugSplatSymbols;
 };

--- a/Source/BugSplat/Public/BugSplat.h
+++ b/Source/BugSplat/Public/BugSplat.h
@@ -6,18 +6,7 @@
 #include "Modules/ModuleManager.h"
 #include <Runtime/SlateCore/Public/Widgets/SUserWidget.h>
 #include "BugSplatSettings.h"
-
-class FToolBarBuilder;
-class FMenuBuilder;
-
-enum BugSplatInputField
-{
-	ClientID,
-	ClientSecret,
-	Database,
-	ApplicationName,
-	Version
-};
+#include "BugSplatSymbols.h"
 
 class FBugSplatModule : public IModuleInterface
 {
@@ -37,13 +26,7 @@ public:
 	FReply OnUpdateWindowsSymbolUploadScript();
 
 private:
-
-	void RegisterMenus();
-
-	TSharedRef<class SBox> CreateBugSplatWindowContent();
-	TSharedPtr<SVerticalBox> CreateInputFieldWidget(FText InputFieldName, BugSplatInputField InputFieldType);
-
-private:
 	TSharedPtr<class FUICommandList> PluginCommands;
 	FBugSplatSettings* BugSplatSettings;
+	FBugSplatSymbols* BugSplatSymbols;
 };

--- a/Source/BugSplat/Public/BugSplatCrashReportClient.h
+++ b/Source/BugSplat/Public/BugSplatCrashReportClient.h
@@ -20,14 +20,15 @@ class FBugSplatCrashReportClient
 public:
 	FBugSplatCrashReportClient();
 
-	FString CreateBugSplatEndpointUrl();
-
-	void UpdateLocalIni();
-	void UpdateGlobalIni();
+	void UpdatePackagedBuildSettings();
+	void UpdateEngineSettings();
 
 private:
+	FString CreateBugSplatEndpointUrl(FString Database, FString App, FString Version);
+	void CreateEmptyTextFile(FString FullPath);
+
 	FString GetPackagedBuildPlatformTarget(FString Platform);
 	FString GetPackagedBuildDefaultEngineIniRelativePath();
-	void CreateEmptyTextFile(FString FullPath);
-	void UpdateCrashReportClientIni(FString iniFilePath);
+
+	void UpdateCrashReportClientIni(FString Database, FString App, FString Version, FString DefaultEngineIniFilePath);
 };

--- a/Source/BugSplat/Public/BugSplatCrashReportClient.h
+++ b/Source/BugSplat/Public/BugSplatCrashReportClient.h
@@ -15,10 +15,10 @@ static const FString PACKAGED_BUILD_CONFIG_PATH_4_25_AND_OLDER = FString("Engine
 
 static const FString INI_FILE_NAME = FString("DefaultEngine.ini");
 
-class FBugSplatSettings
+class FBugSplatCrashReportClient
 {
 public:
-	FBugSplatSettings();
+	FBugSplatCrashReportClient();
 
 	FString CreateBugSplatEndpointUrl();
 

--- a/Source/BugSplat/Public/BugSplatEditorSettingsCustomization.h
+++ b/Source/BugSplat/Public/BugSplatEditorSettingsCustomization.h
@@ -8,7 +8,7 @@
 class SErrorText;
 class IPropertyHandle;
 
-class FBugSplatSettingsCustomization : public IDetailCustomization
+class FBugSplatEditorSettingsCustomization : public IDetailCustomization
 {
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();

--- a/Source/BugSplat/Public/BugSplatSettings.h
+++ b/Source/BugSplat/Public/BugSplatSettings.h
@@ -4,13 +4,8 @@
 
 #include "CoreMinimal.h"
 #include <EngineSharedPCH.h>
-#include "Interfaces/IPluginManager.h"
-
-static const FString PLUGIN_BASE_DIR = FPaths::ConvertRelativePathToFull(IPluginManager::Get().FindPlugin(TEXT("BugSplat"))->GetBaseDir());
 
 static const FString BUGSPLAT_ENDPOINT_URL_FORMAT = FString("https://{0}.bugsplat.com/post/ue4/{1}/{2}");
-static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(PLUGIN_BASE_DIR, FString("/Source/ThirdParty/SymUploader/symbol-upload-win.exe"));
-static const FString BUGSPLAT_BASH_DIR = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/Source/Scripts/BugSplat.bat"));
 
 static const FString GLOBAL_CRASH_REPORT_CLIENT_CONFIG_PATH = *FPaths::Combine(FPaths::EngineDir(), FString("Programs/CrashReportClient/Config/DefaultEngine.ini"));
 
@@ -29,7 +24,6 @@ public:
 
 	void UpdateLocalIni();
 	void UpdateGlobalIni();
-	void WriteSymbolUploadScript();
 
 private:
 	FString GetPackagedBuildPlatformTarget(FString Platform);

--- a/Source/BugSplat/Public/BugSplatSettings.h
+++ b/Source/BugSplat/Public/BugSplatSettings.h
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #pragma once	
 

--- a/Source/BugSplat/Public/BugSplatSettingsCustomization.h
+++ b/Source/BugSplat/Public/BugSplatSettingsCustomization.h
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #pragma once
 

--- a/Source/BugSplat/Public/BugSplatSymbols.h
+++ b/Source/BugSplat/Public/BugSplatSymbols.h
@@ -15,6 +15,9 @@ class FBugSplatSymbols
 public:
 	FBugSplatSymbols();
 
-	void WriteSymbolUploadScript();
+	void UpdateSymbolUploadsSettings();
+	FString CreateSymbolUploadScript(FString Database, FString App, FString Version, FString ClientId, FString ClientSecret);
 
+private:
+	void WriteSymbolUploadScript(FString contents);
 };

--- a/Source/BugSplat/Public/BugSplatSymbols.h
+++ b/Source/BugSplat/Public/BugSplatSymbols.h
@@ -1,0 +1,20 @@
+// Copyright 2023 BugSplat. All Rights Reserved.
+
+#pragma once	
+
+#include "CoreMinimal.h"
+#include <EngineSharedPCH.h>
+#include "Interfaces/IPluginManager.h"
+
+static const FString PLUGIN_BASE_DIR = FPaths::ConvertRelativePathToFull(IPluginManager::Get().FindPlugin(TEXT("BugSplat"))->GetBaseDir());
+static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(PLUGIN_BASE_DIR, FString("/Source/ThirdParty/SymUploader/symbol-upload-win.exe"));
+static const FString BUGSPLAT_BASH_DIR = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/Source/Scripts/BugSplat.bat"));
+
+class FBugSplatSymbols
+{
+public:
+	FBugSplatSymbols();
+
+	void WriteSymbolUploadScript();
+
+};

--- a/Source/BugSplatRuntime/BugSplatRuntime.Build.cs
+++ b/Source/BugSplatRuntime/BugSplatRuntime.Build.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 using System.IO;
 using UnrealBuildTool;

--- a/Source/BugSplatRuntime/Bugsplat_Android_UPL.xml
+++ b/Source/BugSplatRuntime/Bugsplat_Android_UPL.xml
@@ -4,7 +4,7 @@
         <log text="BugSplat SDK Android UPL initialization"/>
 
         <setBoolFromProperty result="bEnableCrashReporting" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="bEnableCrashReportingAndroid" default="true" />
-        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="bUploadDebugSymbolsAndroid" default="true" />
+        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="bUploadDebugSymbols" default="true" />
 
         <setStringFromProperty result="bugsplatDatabase" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="BugSplatDatabase" />
         <setStringFromProperty result="bugsplatApp" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="BugSplatApp" />

--- a/Source/BugSplatRuntime/Bugsplat_IOS_UPL.xml
+++ b/Source/BugSplatRuntime/Bugsplat_IOS_UPL.xml
@@ -5,7 +5,7 @@
         <copyDir src="$S(PluginDir)/../ThirdParty/IOS/Bugsplat.framework" dst="$S(BuildDir)/Frameworks/Bugsplat.framework" />
 
         <setBoolFromProperty result="bEnableCrashReporting" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="bEnableCrashReportingIos" default="true" />
-        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="bUploadDebugSymbolsIos" default="true" />
+        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="bUploadDebugSymbols" default="true" />
 
         <setStringFromProperty result="DatabaseName" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="BugSplatDatabase"/>
         <setStringFromProperty result="VersionNumber" ini="Engine" section="/Script/BugSplatRuntime.BugSplatEditorSettings" property="BugSplatVersion"/>

--- a/Source/BugSplatRuntime/Private/BugSplatEditorSettings.cpp
+++ b/Source/BugSplatRuntime/Private/BugSplatEditorSettings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplatEditorSettings.h"
 

--- a/Source/BugSplatRuntime/Private/BugSplatEditorSettings.cpp
+++ b/Source/BugSplatRuntime/Private/BugSplatEditorSettings.cpp
@@ -6,11 +6,36 @@ UBugSplatEditorSettings::UBugSplatEditorSettings(const FObjectInitializer& Objec
 	: Super(ObjectInitializer)
 {
 	BugSplatDatabase = TEXT("");
+	BugSplatApp = TEXT("");
+	BugSplatVersion = TEXT("");
 	BugSplatClientId = TEXT("");
 	BugSplatClientSecret = TEXT("");
-	BugSplatVersion = TEXT("");
+	bUpdateEngineDataRouterUrl = true;
+	bUploadDebugSymbols = true;
 	bEnableCrashReportingIos = true;
-	bUploadDebugSymbolsIos = true;
 	bEnableCrashReportingAndroid = true;
-	bUploadDebugSymbolsAndroid = true;
 }
+
+bool UBugSplatEditorSettings::HasValidCrashReporterSettings() const
+{
+	return !BugSplatDatabase.IsEmpty() && !BugSplatApp.IsEmpty() && !BugSplatVersion.IsEmpty();
+}
+
+bool UBugSplatEditorSettings::HasValidSymbolUploadSettings() const
+{
+	return !BugSplatDatabase.IsEmpty() && !BugSplatApp.IsEmpty() && !BugSplatVersion.IsEmpty() && !BugSplatClientId.IsEmpty() && !BugSplatClientSecret.IsEmpty();
+}
+
+#if WITH_EDITOR
+bool UBugSplatEditorSettings::CanEditChange(const FProperty* InProperty) const
+{
+	const bool ParentVal = Super::CanEditChange(InProperty);
+
+	if (InProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UBugSplatEditorSettings, bUploadDebugSymbols))
+	{
+		return ParentVal && HasValidSymbolUploadSettings();
+	}
+
+	return ParentVal;
+}
+#endif

--- a/Source/BugSplatRuntime/Private/BugSplatRuntime.cpp
+++ b/Source/BugSplatRuntime/Private/BugSplatRuntime.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplatRuntime.h"
 #include "BugSplatEditorSettings.h"

--- a/Source/BugSplatRuntime/Private/BugSplatUtils.cpp
+++ b/Source/BugSplatRuntime/Private/BugSplatUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #include "BugSplatUtils.h"
 

--- a/Source/BugSplatRuntime/Public/BugSplatEditorSettings.h
+++ b/Source/BugSplatRuntime/Public/BugSplatEditorSettings.h
@@ -11,34 +11,41 @@ class BUGSPLATRUNTIME_API UBugSplatEditorSettings : public UObject
 	GENERATED_UCLASS_BODY()
 
 public:
-	UPROPERTY(Config, EditAnywhere, Category = "Common", Meta = (DisplayName = "Database", ToolTip = "Database name"))
+#if WITH_EDITOR
+	virtual bool CanEditChange(const FProperty* InProperty) const override;
+#endif
+
+	bool HasValidCrashReporterSettings(void) const;
+	bool HasValidSymbolUploadSettings(void) const;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Settings", Meta = (DisplayName = "Database", ToolTip = "Database name"))
 	FString BugSplatDatabase;
 
-	UPROPERTY(Config, EditAnywhere, Category = "Common", Meta = (DisplayName = "Application", ToolTip = "Application name"))
+	UPROPERTY(Config, EditAnywhere, Category = "Settings", Meta = (DisplayName = "Application", ToolTip = "Application name"))
 	FString BugSplatApp;
 
-	UPROPERTY(Config, EditAnywhere, Category = "Common", Meta = (DisplayName = "Version", ToolTip = "Application version number"))
+	UPROPERTY(Config, EditAnywhere, Category = "Settings", Meta = (DisplayName = "Version", ToolTip = "Application version number"))
 	FString BugSplatVersion;
 
-	UPROPERTY(Config, EditAnywhere, Category = "Common", Meta = (DisplayName = "ClientId", ToolTip = "Client ID (required for debug symbol uploads)"))
+	UPROPERTY(Config, EditAnywhere, Category = "Settings", Meta = (DisplayName = "Client Id", ToolTip = "OAuth Client ID (required for debug symbol uploads)"))
 	FString BugSplatClientId;
 
-	UPROPERTY(Config, EditAnywhere, Category = "Common", Meta = (DisplayName = "ClientSecret", ToolTip = "Client secret (required for debug symbol uploads)"))
+	UPROPERTY(Config, EditAnywhere, Category = "Settings", Meta = (DisplayName = "Client Secret", ToolTip = "OAuth Client Secret (required for debug symbol uploads)"))
 	FString BugSplatClientSecret;
 
-	UPROPERTY(Config, EditAnywhere, Category = "IOS",
-		Meta = (DisplayName = "Enable iOS crash reporting", ToolTip = "Flag indicating whether to capture crashes on iOS"))
+	UPROPERTY(Config, EditAnywhere, Category = "Settings",
+		Meta = (DisplayName = "Update Engine DataRouterUrl", ToolTip = "Automatically update engine's DefaultEngine.ini when Database, Application, or Version chages"))
+	bool bUpdateEngineDataRouterUrl;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Settings",
+		Meta = (DisplayName = "Enable Automatic Symbol Uploads", ToolTip = "Flag indicating whether to upload debug symbols automatically"))
+	bool bUploadDebugSymbols;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Settings",
+		Meta = (DisplayName = "Enable Android Crash Reporting", ToolTip = "Flag indicating whether to capture crashes on Android"))
+		bool bEnableCrashReportingAndroid;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Settings",
+		Meta = (DisplayName = "Enable iOS Crash Reporting", ToolTip = "Flag indicating whether to capture crashes on iOS"))
 	bool bEnableCrashReportingIos;
-
-	UPROPERTY(Config, EditAnywhere, Category = "IOS",
-		Meta = (DisplayName = "Enable automatic symbols uploads", ToolTip = "Flag indicating whether to upload iOS debug symbols automatically", EditCondition = "bEnableCrashReportingIos"))
-	bool bUploadDebugSymbolsIos;
-
-	UPROPERTY(Config, EditAnywhere, Category = "Android",
-		Meta = (DisplayName = "Enable Android crash reporting", ToolTip = "Flag indicating whether to capture crashes on Android"))
-	bool bEnableCrashReportingAndroid;
-
-	UPROPERTY(Config, EditAnywhere, Category = "Android",
-		Meta = (DisplayName = "Enable automatic symbols uploads", ToolTip = "Flag indicating whether to upload Android debug symbols automatically", EditCondition = "bEnableCrashReportingAndroid"))
-	bool bUploadDebugSymbolsAndroid;
 };

--- a/Source/BugSplatRuntime/Public/BugSplatEditorSettings.h
+++ b/Source/BugSplatRuntime/Public/BugSplatEditorSettings.h
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #pragma once
 

--- a/Source/BugSplatRuntime/Public/BugSplatRuntime.h
+++ b/Source/BugSplatRuntime/Public/BugSplatRuntime.h
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #pragma once
 

--- a/Source/BugSplatRuntime/Public/BugSplatUtils.h
+++ b/Source/BugSplatRuntime/Public/BugSplatUtils.h
@@ -1,4 +1,4 @@
-// Copyright 2022 BugSplat. All Rights Reserved.
+// Copyright 2023 BugSplat. All Rights Reserved.
 
 #pragma once
 

--- a/Source/Scripts/upload-symbols-win64.bat
+++ b/Source/Scripts/upload-symbols-win64.bat
@@ -2,6 +2,7 @@
 
 set targetPlatform=%1
 set projectDir=%2
+set targetName=%3
 set uploadScriptPath=%projectDir%\Plugins\BugSplat\Source\Scripts\BugSplat.bat
 
 echo "BugSplat [INFO]: invoking upload script at %uploadScriptPath%"
@@ -11,4 +12,4 @@ if not exist "%uploadScriptPath%" (
 	exit /b
 )
 
-call %uploadScriptPath% %targetPlatform%
+call %uploadScriptPath% %targetPlatform% %targetName%


### PR DESCRIPTION
### Description

**TODO BG**
- [ ] Update mobile platforms to use bUploadDebugSymbols
- [ ] Update copyright dates
- [ ] Test mobile platforms

We've had a ton of customers who need help understanding the difference between Update Game INI and Update Global INI. This change will automatically keep the global DefaultEngine.ini files DataRouterUrl in sync with the value specified by the plugin. 

Additionally, this fixes an issue where we'd upload symbols if the user was trying to start the editor.

Fixes #66 

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
