### PR TITLE
fix: proguard additions for the `crashpad` wrapper

### DIFF
--- a/Source/BugSplatRuntime/Bugsplat_Android_UPL.xml
+++ b/Source/BugSplatRuntime/Bugsplat_Android_UPL.xml
@@ -155,4 +155,11 @@
         </if>
     </buildGradleAdditions>
 
+    <proguardAdditions>
+        <insert>
+            -keep class com.ninevastudios.bugsplatunitylib.BugSplatBridge { *; }
+            -keepclassmembers class com.ninevastudios.bugsplatunitylib.BugSplatBridge { *; }
+        </insert>
+    </proguardAdditions>
+
 </root>


### PR DESCRIPTION
This PR addresses an issue when the `crashpad` wrapper gets stripped in Android Shipping builds.
