### PR TITLE
feat: macos and linux symbol uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ DerivedDataCache/*
 Source/Scripts/BugSplat.bat
 Source/Scripts/upload-symbols-win64.ps1
 Source/Scripts/upload-symbols-mac.sh
+Source/Scripts/upload-symbols-linux.sh
 
 # Mac OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You may choose to add BugSplat through the Unreal Marketplace or add the plugin 
 
 1. Navigate to your project folder containing your `[ProjectName].uproject` file.
 2. Create a `Plugins` folder if it does not already exist.
-3. Create a `BugSplat` folder in the `Plugins` folder and copy the contents of this repo into the `BugSplat` folder. Please note, if you're cloning this repo on macOS or Linux, you'll need to use [Git LFS](https://git-lfs.com/) and `git lfs fetch --all` to download our [symbol-upload](https://github.com/BugSplat-Git/bugsplat-unreal/tree/main/Source/ThirdParty/SymUploader) tool.
+3. Create a `BugSplat` folder in the `Plugins` folder and copy the contents of this repo into the `BugSplat` folder. 
 4. In the Unreal Editor, ensure you can access the BugSplat plugin via `Edit > Project Settings` and scroll to the `BugSplat` section under `Plugins`.
 
 ## ⚙️ Configuration
@@ -56,6 +56,15 @@ BugSplat leverages Unreal's `CrashReportClient` to provide crash reporting for W
 To configure `CrashReportClient` to post to BugSplat, the `DataRouterUrl` value needs to be added to `DefaultEngine.ini`. The `bugsplat-unreal` plugin automatically updates the value for `DataRouterUrl` when the `Update Engine DefaultEngine.ini` option is enabled. Please note the `DataRouterUrl` value is global and is shared across all packaged builds created by the affected engine. To override the `DataRouterUrl` value a package build uses, you may optionally use the `Update Packaged Game INI` button under the `Tools` section.
 
 In order to get function names and line numbers in crash reports, you'll need to upload your game's `.exe`, `.dll`, and `.pdb` files. To upload debug symbols for reach build, ensure that the `Enable Automatic Symbol Uploads` option is selected. When selected, a script to execute [symbol-upload](https://github.com/BugSplat-Git/symbol-upload) will be added to the `PostBuildSteps` field in `BugSplat.uplugin`. The symbol upload script will run automatically when your game is built.
+
+#### macOS
+
+To create a `.dSYM` file for a macOS build invoke `RunUAT.command` with the `-EnableDSym` flag per the example below:
+
+```sh
+../../../Engine/Build/BatchFiles/Mac/Build.sh -Project="../../my-unreal-crasher/MyUnrealCrasher.uproject" MyUnrealCrasher Mac Development -NoEditor -EnableDSym -TargetPath="~/Desktop/UnrealEngine"
+```
+
 
 ### iOS and Android
 

--- a/Source/BugSplat/Private/BugSplatSymbols.cpp
+++ b/Source/BugSplat/Private/BugSplatSymbols.cpp
@@ -74,7 +74,7 @@ FString FBugSplatSymbols::CreateSymbolUploadScript(FString Database, FString App
 	return FString::Format(*PostBuildStepsConsoleCommandFormat, args);
 #elif PLATFORM_MAC
 	FString TargetPlatformCheck = TEXT("if [ -z \"$1\" ]; then\n    echo \"BugSplat [ERROR]: Symbol upload invocation missing target platform...\"\n    exit 1\nfi\n");
-	FString PlatformGuard = TEXT("if [ \"$1\" != \"Mac\" ] && [ \"$1\" != \"IOS\" ]; then\n    echo \"BugSplat [INFO]: Non-Apple build detected, skipping Mac/iOS symbol uploads...\"\n    exit 0\nfi\n");
+	FString PlatformGuard = TEXT("if [ \"$1\" != \"Mac\" ]; then\n    echo \"BugSplat [INFO]: Non-Mac build detected, skipping Mac symbol uploads...\"\n    exit 0\nfi\n");
 
 	FString PostBuildStepsConsoleCommandFormat =
 		FString(

--- a/Source/BugSplat/Private/BugSplatSymbols.cpp
+++ b/Source/BugSplat/Private/BugSplatSymbols.cpp
@@ -104,6 +104,38 @@ FString FBugSplatSymbols::CreateSymbolUploadScript(FString Database, FString App
 	args.Add(FString("**/*.{app,dSYM}"));
 
 	return FString::Format(*PostBuildStepsConsoleCommandFormat, args);
+#elif PLATFORM_LINUX
+	FString TargetPlatformCheck = TEXT("if [ -z \"$1\" ]; then\n    echo \"BugSplat [ERROR]: Symbol upload invocation missing target platform...\"\n    exit 1\nfi\n");
+	FString PlatformGuard = TEXT("if [ \"$1\" != \"Linux\" ]; then\n    echo \"BugSplat [INFO]: Non-Linux build detected, skipping Linux symbol uploads...\"\n    exit 0\nfi\n");
+
+	FString PostBuildStepsConsoleCommandFormat =
+		FString(
+			"#!/bin/bash\n"
+			"{0}\n"          // Target Platform Check
+			"{1}\n"          // Platform Guard
+			"\"{2}\" "       // Uploader Path
+			"-i {3} "        // Client ID
+			"-s {4} "        // Client Secret
+			"-b {5} "        // Database
+			"-a \"{6}\" "    // Application
+			"-v \"{7}\" "    // Version
+			"-d \"{8}/$1\" " // Output Directory
+			"-f \"{9}\" "    // File Pattern
+		);
+
+	FStringFormatOrderedArguments args;
+	args.Add(TargetPlatformCheck);
+	args.Add(PlatformGuard);
+	args.Add(BUGSPLAT_SYMBOL_UPLOADER_PATH);
+	args.Add(ClientId);
+	args.Add(ClientSecret);
+	args.Add(Database);
+	args.Add(App);
+	args.Add(Version);
+	args.Add(FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), FString("Binaries")));
+	args.Add(FString("**/*.sym"));
+
+	return FString::Format(*PostBuildStepsConsoleCommandFormat, args);
 #else
 	return TEXT("echo \"BugSplat [INFO]: Symbol uploads not supported on this platform\"");
 #endif

--- a/Source/BugSplat/Public/BugSplatSymbols.h
+++ b/Source/BugSplat/Public/BugSplatSymbols.h
@@ -11,6 +11,9 @@ static const FString PLUGIN_BASE_DIR = FPaths::ConvertRelativePathToFull(IPlugin
 #if PLATFORM_MAC
 static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(PLUGIN_BASE_DIR, FString("/Source/ThirdParty/SymUploader/symbol-upload-macos"));
 static const FString BUGSPLAT_SYMBOL_UPLOAD_SCRIPT_PATH = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/Source/Scripts/upload-symbols-mac.sh"));
+#elif PLATFORM_LINUX
+static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(PLUGIN_BASE_DIR, FString("/Source/ThirdParty/SymUploader/symbol-upload-linux"));
+static const FString BUGSPLAT_SYMBOL_UPLOAD_SCRIPT_PATH = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/Source/Scripts/upload-symbols-linux.sh"));
 #else
 static const FString BUGSPLAT_SYMBOL_UPLOADER_PATH = *FPaths::Combine(PLUGIN_BASE_DIR, FString("/Source/ThirdParty/SymUploader/symbol-upload-windows.exe"));
 static const FString BUGSPLAT_SYMBOL_UPLOAD_SCRIPT_PATH = *FPaths::Combine(FPaths::ProjectDir(), FString("Plugins/BugSplat/Source/Scripts/upload-symbols-win64.ps1"));

--- a/Source/Scripts/post-build-linux.sh
+++ b/Source/Scripts/post-build-linux.sh
@@ -30,4 +30,9 @@ if [ "$targetPlatform" != "Linux" ]; then
     exit
 fi
 
-echo "BugSplat [WARN]: Symbol uploads for Linux are not supported yet"
+if [ -f "$scriptsPath/upload-symbols-linux.sh" ]; then
+    echo "BugSplat [INFO]: Running upload-symbols-linux.sh"
+    sh "$scriptsPath/upload-symbols-linux.sh" "$targetPlatform"
+else
+    echo "BugSplat [WARN]: Symbol uploads not configured via plugin - skipping..."
+fi

--- a/Source/Scripts/post-build-linux.sh
+++ b/Source/Scripts/post-build-linux.sh
@@ -32,7 +32,7 @@ fi
 
 if [ -f "$scriptsPath/upload-symbols-linux.sh" ]; then
     echo "BugSplat [INFO]: Running upload-symbols-linux.sh"
-    sh "$scriptsPath/upload-symbols-linux.sh" "$targetPlatform"
+    sh "$scriptsPath/upload-symbols-linux.sh" "$targetPlatform" "$targetName"
 else
     echo "BugSplat [WARN]: Symbol uploads not configured via plugin - skipping..."
 fi

--- a/Source/Scripts/post-build-mac.sh
+++ b/Source/Scripts/post-build-mac.sh
@@ -32,7 +32,7 @@ fi
 
 if [ "$targetPlatform" == "Mac" ] && [ -f "$scriptsPath/upload-symbols-mac.sh" ]; then
     echo "BugSplat [INFO]: Running upload-symbols-mac.sh"
-    sh "$scriptsPath/upload-symbols-mac.sh"
+    sh "$scriptsPath/upload-symbols-mac.sh" "$targetPlatform" "$targetName"
     exit
 elif [ "$targetPlatform" == "Mac" ]; then
     echo "BugSplat [WARN]: Symbol uploads not configured via plugin - skipping..."

--- a/Source/Scripts/post-build-mac.sh
+++ b/Source/Scripts/post-build-mac.sh
@@ -32,7 +32,7 @@ fi
 
 if [ "$targetPlatform" == "Mac" ] && [ -f "$scriptsPath/upload-symbols-mac.sh" ]; then
     echo "BugSplat [INFO]: Running upload-symbols-mac.sh"
-    sh "$scriptsPath/upload-symbols-mac.sh" -f "$binariesPath/$targetName.zip" -u "$uploaderPath"
+    sh "$scriptsPath/upload-symbols-mac.sh"
     exit
 elif [ "$targetPlatform" == "Mac" ]; then
     echo "BugSplat [WARN]: Symbol uploads not configured via plugin - skipping..."


### PR DESCRIPTION
### Description

* Add logic to create Linux symbol upload script
* Add README snippet about building macOS with dSYM
* Fix macOS invocation args
* Remove README note about symbol uploads and git lfs (no longer needed)

Fixes #5 Fixes #17 

### TODO BG
- [x] Test macOS
- [x] Test Linux

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
