### PR TITLE
fix: require 5.3 for attributes

### DIFF
--- a/Source/BugSplatRuntime/Private/BugSplatRuntime.cpp
+++ b/Source/BugSplatRuntime/Private/BugSplatRuntime.cpp
@@ -45,7 +45,7 @@ TMap<FString, FString> FBugSplatRuntimeModule::GetCrashAttributes() const
 {
 	TMap<FString, FString> Attributes;
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	// Add engine information
 	Attributes.Add(TEXT("EngineVersion"), FEngineVersion::Current().ToString());
 	Attributes.Add(TEXT("EngineBranch"), FEngineVersion::Current().GetBranch());


### PR DESCRIPTION
### Description

Fixes errors uploading to FAB

* GetEngineData was added in [5.3.0-preview-1](https://github.com/EpicGames/UnrealEngine/commit/be62f350c8d9774d9c570669734f6ecb79fc3712)
* GetGameData was added in [5.3.0-preview-1](https://github.com/EpicGames/UnrealEngine/commit/be62f350c8d9774d9c570669734f6ecb79fc3712)
* GetIsWithDebugInfo was also added in [5.3.0-preview-1](https://github.com/EpicGames/UnrealEngine/commit/6bdae7d69eb70ead0cbdcb71a4b0b8cbd60ed837)


### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
